### PR TITLE
Add GitHub Actions workflow for Docker image build and push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,25 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: docker build -t ghcr.io/${{ github.repository }}/nextjs-app:${{ github.sha }} .
+
+      - name: Push Docker image
+        run: docker push ghcr.io/${{ github.repository }}/nextjs-app:${{ github.sha }}


### PR DESCRIPTION
**This pull request introduces a CI/CD workflow using GitHub Actions to automatically build the Next.js application Docker image and publish it to GitHub Container Registry (GHCR) when code is pushed to the main branch.**

Features:

1. Workflow is defined in .github/workflows/docker-image.yml
2. Triggers on every push to the main branch
3. Logs in to GHCR using GitHub token
4. Builds, tags, and pushes Docker image using the existing Dockerfile and commit SHA

Purpose:
Automates Docker image creation and publishing to streamline deployment and support future Kubernetes integration.